### PR TITLE
Fix order of posts and pages

### DIFF
--- a/js/cms.js
+++ b/js/cms.js
@@ -100,7 +100,8 @@ var CMS = {
 		}
 	},
 
-	renderPage: function(title) {
+        renderPage: function(title) {
+	        CMS.pages.sort(function(a,b) {return a.date - b.date});
 		CMS.pages.forEach(function(page){
 			if(page.title == title) {
 
@@ -133,7 +134,8 @@ var CMS = {
 		CMS.renderFooter();
 	},
 
-	renderPosts: function() {
+        renderPosts: function() {
+	        CMS.posts.sort(function(a,b) {return a.date - b.date});
 		CMS.posts.forEach(function(post){
 			var tpl = $('#post-template').html(),
 				$tpl = $(tpl);


### PR DESCRIPTION
Solve [issue 2](https://github.com/cdmedia/cms.js/issues/2).

Just sort the CMS.posts and CMS.pages before the loop that renders them.
And that works fine :+1: ! 
