### PR TITLE
fixed option: blog/static frontpage and posts listing

### DIFF
--- a/js/cms.js
+++ b/js/cms.js
@@ -71,10 +71,20 @@ var CMS = {
     CMS.settings.footerContainer.hide();
 
     var type = url.split('/')[0];
+
     var map = {
 
-      // Main view
+      // Main view / Frontpage
       '' : function () {
+        if (CMS.settings.pageAsFrontpage == true) {
+          CMS.renderPosts();
+        } else {
+          CMS.renderPage(CMS.settings.pageAsFrontpage);
+        }
+      },
+
+      // Posts on Url
+      [CMS.settings.postsOnUrl] : function () {
         CMS.renderPosts();
       },
 

--- a/js/cms.js
+++ b/js/cms.js
@@ -83,12 +83,7 @@ var CMS = {
         }
       },
 
-      // Posts on Url
-      [CMS.settings.postsOnUrl] : function () {
-        CMS.renderPosts();
-      },
-
-      // Post view
+      // Post view / single view
       '#post' : function () {
         var id = url.split('#post/')[1].trim();
         CMS.renderPost(id);
@@ -101,6 +96,22 @@ var CMS = {
       }
 
     };
+
+    // Listing of posts
+    // Posts on Url: posts not on frontpage && config empty ==> '#posts'
+    if (CMS.settings.postsOnFrontpage == false && CMS.settings.postsOnUrl == '') {
+      map["#posts"] = function () {
+        CMS.renderPosts();
+      };
+    // Posts on Url: posts not on frontpage && user config ==> '#userconfig'
+    } else if (CMS.settings.postsOnFrontpage == false && CMS.settings.postsOnUrl !== '') {
+      map[ CMS.settings.postsOnUrl ] = function () {
+        CMS.renderPosts();
+      };
+    }
+
+
+
 
     if (map[type]) {
       map[type]();

--- a/js/config.js
+++ b/js/config.js
@@ -32,7 +32,7 @@ $(function() {
     // Order of sorting (true for newest to oldest)
     sortDateOrder: true,
 
-    // Posts on Frontpage (blog style) 
+    // Posts on Frontpage (blog style)
     postsOnFrontpage: true,
 
     // Page as Frontpage (static)

--- a/js/config.js
+++ b/js/config.js
@@ -32,6 +32,15 @@ $(function() {
     // Order of sorting (true for newest to oldest)
     sortDateOrder: true,
 
+    // Posts on Frontpage (blog style) 
+    postsOnFrontpage: true,
+
+    // Page as Frontpage (static)
+    pageAsFrontpage: '',
+
+    // Posts/Blog on different URL
+    postsOnUrl: '#post',
+
     // Site fade speed
     fadeSpeed: 300,
 

--- a/js/config.js
+++ b/js/config.js
@@ -27,10 +27,10 @@ $(function() {
     postSnippetLength: 120,
 
     // Pages folder name
-          pagesFolder: 'pages',
+    pagesFolder: 'pages',
 
-          // Order of sorting (true for newest to oldest)
-          sortDateOrder: true,
+    // Order of sorting (true for newest to oldest)
+    sortDateOrder: true,
 
     // Site fade speed
     fadeSpeed: 300,

--- a/js/config.js
+++ b/js/config.js
@@ -39,7 +39,7 @@ $(function() {
     pageAsFrontpage: '',
 
     // Posts/Blog on different URL
-    postsOnUrl: '#post',
+    postsOnUrl: '',
 
     // Site fade speed
     fadeSpeed: 300,

--- a/js/config.js
+++ b/js/config.js
@@ -2,7 +2,7 @@ $(function() {
 
   CMS.init({
 
-    // Name of your site or location of logo file ,relative to root directory (img/logo.png)
+    // Name of your site or location of logo file, relative to root directory (img/logo.png)
     siteName: 'My Site',
 
     // Tagline for your site


### PR DESCRIPTION
Hi,

better handling of options in different cases:
- default: frontpage = '' = blog
- user option: blog not on frontpage, instead page as frontpage,
  listing of posts defaults to #posts in that case
- user option: blog not on frontpage, instead oage as frontpage
  and in the config user can choose an url for the listing: #mypostings

this can be done more elegant and skilled in js, as well as the logic
of options in the config.js file could be done easier of others.

I pr nevertheless, perhaps the code is of some use for others, for
this nice project!

thanks
