### PR TITLE
fixes for #35, #36 and #37

### DIFF
--- a/js/cms.js
+++ b/js/cms.js
@@ -5,6 +5,7 @@
  * Free to use under the MIT license.
  * http://www.opensource.org/licenses/mit-license.php
  */
+'use strict';
 
 var CMS = {
 
@@ -248,7 +249,8 @@ var CMS = {
 
   getContent: function (type, file, counter, numFiles) {
 
-    var urlFolder = '';
+    var urlFolder = '',
+        url;
 
     switch(type) {
       case 'post':
@@ -262,7 +264,7 @@ var CMS = {
     if (CMS.settings.mode == 'Github') {
       url = file.link;
     } else {
-      url = urlFolder + '/' + file.name;
+      url = file.name;
     }
 
     $.ajax({
@@ -306,7 +308,8 @@ var CMS = {
       success: function (data) {
 
         var files = [],
-          linkFiles;
+          linkFiles,
+          dateParser = /\d{4}-\d{2}(?:-d{2})?/; // can parse both 2016-01 and 2016-01-01
 
         if (CMS.settings.mode == 'Github') {
           linkFiles = data;
@@ -328,7 +331,7 @@ var CMS = {
 
           if (filename.endsWith('.md')) {
             var file = {};
-            file.date = new Date(filename.substring(0, 10));
+            file.date = new Date(dateParser.test(filename) && dateParser.exec(filename)[0]);
             file.name = filename;
             if (downloadLink) {
               file.link = downloadLink;


### PR DESCRIPTION
While testing if cms.js would work with [ecstatic](https://github.com/jfhbrook/node-ecstatic), I stumbled upon some bugs that, I first reported and then fixed. I've tested with [ecstatic](https://github.com/jfhbrook/node-ecstatic) as server in _"Apache"_ mode and in _"Github"_ mode on [my gh-pages](http://dotnetcarpenter.github.io/cms.js/).
#35 `url` was defined without `var` - fixed and added `'use strict'` pragma to catch reference errors in the future.
#36 the `file` object argument to `getContent` has a `name` property which already has the correct URL to the file, so it's an error to add the `urlFolder` to the URL string. Consequently, the switch statement starting at line 255 can probably be removed. We'll have to be sure that the `file.name` property is always correct but I haven't had time. Expect one or two more commits here.
#37 The date parsing expect a very stringent naming scheme, one that the example `.md` file doesn't even follow. I've made a regex which will match YYYY-MM-DD and YYYY-MM anywhere in the file name.
