### PR TITLE
quickfix for #36

### DIFF
--- a/js/cms.js
+++ b/js/cms.js
@@ -264,7 +264,7 @@ var CMS = {
     if (CMS.settings.mode == 'Github') {
       url = file.link;
     } else {
-      url = urlFolder + '/' + file.name;
+      url = file.name.indexOf(urlFolder) > -1 ? file.name : urlFolder + '/' + file.name;
     }
 
     $.ajax({


### PR DESCRIPTION
I think I got it. Apache returns a document where the <a href is just the file name and ecstatic returns a document where the <a href is the full qualified url from the root.
