### PR TITLE
Regex fix and swtiched to UTC date methods

### DIFF
--- a/js/cms.js
+++ b/js/cms.js
@@ -131,7 +131,7 @@ var CMS = {
           $tpl = $(tpl);
 
         $tpl.find('.post-title').html(post.title);
-        $tpl.find('.post-date').html((post.date.getMonth() + 1) + '/' + post.date.getDate() + '/' +  post.date.getFullYear());
+        $tpl.find('.post-date').html((post.date.getUTCMonth() + 1) + '/' + post.date.getUTCDate() + '/' +  post.date.getUTCFullYear());
         $tpl.find('.post-content').html(post.contentData);
 
         CMS.settings.mainContainer.html($tpl).hide().fadeIn(CMS.settings.fadeSpeed);
@@ -147,7 +147,7 @@ var CMS = {
         $tpl = $(tpl);
 
       var title = '<a href="#">' + post.title + '</a>',
-        date = (post.date.getMonth() + 1) + '/' + post.date.getDate() + '/' +  post.date.getFullYear(),
+        date = (post.date.getUTCMonth() + 1) + '/' + post.date.getUTCDate() + '/' +  post.date.getUTCFullYear(),
         snippet = post.contentData.split('.')[0] + '.';
 
       var postLink = $tpl.find('.post-title'),
@@ -309,7 +309,7 @@ var CMS = {
 
         var files = [],
           linkFiles,
-          dateParser = /\d{4}-\d{2}(?:-d{2})?/; // can parse both 2016-01 and 2016-01-01
+          dateParser = /\d{4}-\d{2}(?:-\d{2})?/; // can parse both 2016-01 and 2016-01-01
 
         if (CMS.settings.mode == 'Github') {
           linkFiles = data;


### PR DESCRIPTION
There was a regex bug on master that would only capture the year and month of the filename instead of the date as well.
I also switched all the getters on the date object to use UTC, this way if someone is not in same day as the Prime Meridian it will still render the correct date that was entered in the filename.
