### PR TITLE
Corrected a bug in date parser

### DIFF
--- a/js/cms.js
+++ b/js/cms.js
@@ -309,7 +309,7 @@ var CMS = {
 
         var files = [],
           linkFiles,
-          dateParser = /\d{4}-\d{2}(?:-d{2})?/; // can parse both 2016-01 and 2016-01-01
+          dateParser = /\d{4}-\d{2}(?:-\d{2})?/; // can parse both 2016-01 and 2016-01-01
 
         if (CMS.settings.mode == 'Github') {
           linkFiles = data;


### PR DESCRIPTION
The regexp used for parsing date (dateParser) had a type : it missed a backslash for parsing numbers (\d).
Now it correctly parses 'yyyy-mm-dd' formatted date.

Also, I'd like to have the possibility to select the date format (I'm french, and I don't like mm-dd-yyyy format ^^)
I'm going to do this and pr after ok :) ?
