### PR TITLE
Post separator option and fix for #51

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,7 @@
       <h1 class="post-title"></h1>
       <time class="post-date"></time>
       <div class="post-content"></div>
+      <div id="disqus_thread"></div>
     </article>
   </script>
 

--- a/js/cms.js
+++ b/js/cms.js
@@ -22,6 +22,7 @@ var CMS = {
     pagination: 3,
     postsFolder: 'posts',
     postSnippetLength: 120,
+    postSnippetSeparator: /\s*<!--\s*more\s*-->/,
     pagesFolder: 'pages',
     fadeSpeed: 300,
     mainContainer: $(document.getElementsByClassName('cms_main')),
@@ -143,16 +144,19 @@ var CMS = {
   renderPosts: function () {
     CMS.posts.sort(function (a, b) { return CMS.settings.sortDateOrder ? b.date - a.date : a.date - b.date; });
     CMS.posts.forEach(function (post) {
-      var tpl = $(document.getElementById('post-template')).html(),
-        $tpl = $(tpl);
+      var tpl = $(document.getElementById('post-template')).html();
+      var $tpl = $(tpl);
 
-      var title = '<a href="#">' + post.title + '</a>',
-        date = (post.date.getMonth() + 1) + '/' + post.date.getDate() + '/' +  post.date.getFullYear(),
-        snippet = post.contentData.split('.')[0] + '.';
+      var title = '<a href="#">' + post.title + '</a>';
+      var date = (post.date.getMonth() + 1) + '/' + post.date.getDate() + '/' +  post.date.getFullYear();
+      var snippet = post.contentData.split('.')[0] + '.';
+      if(typeof CMS.settings.postSnippetSeparator === 'object' || typeof CMS.settings.postSnippetSeparator === 'string') {
+        snippet = post.contentData.split(CMS.settings.postSnippetSeparator)[0];
+      } 
 
-      var postLink = $tpl.find('.post-title'),
-        postDate = $tpl.find('.post-date'),
-        postSnippet = $tpl.find('.post-content');
+      var postLink = $tpl.find('.post-title');
+      var postDate = $tpl.find('.post-date');
+      var postSnippet = $tpl.find('.post-content');
 
       postLink.on('click', function (e) {
         e.preventDefault();

--- a/js/cms.js
+++ b/js/cms.js
@@ -227,7 +227,7 @@ var CMS = {
       var $tpl = $(tpl);
 
       var title = '<a href="#">' + post.title + '</a>';
-      var date = (post.date.getMonth() + 1) + '/' + post.date.getDate() + '/' +  post.date.getFullYear();
+      var date = (post.date.getUTCMonth() + 1) + '/' + post.date.getUTCDate() + '/' +  post.date.getUTCFullYear();
       var snippet = '';
       if(typeof CMS.settings.postSnippetSeparator === 'object' || typeof CMS.settings.postSnippetSeparator === 'string') {
         snippet = post.contentData.split(CMS.settings.postSnippetSeparator)[0];
@@ -381,10 +381,10 @@ var CMS = {
     });
   },
 
-  getFiles: function (type) {
+  getFiles: function(type) {
 
-    var folder = '',
-      url = '';
+    var folder = '';
+    var url = '';
 
     switch(type) {
       case 'post':
@@ -396,8 +396,8 @@ var CMS = {
     }
 
     if (CMS.settings.mode == 'Github') {
-      var gus = CMS.settings.githubUserSettings,
-        gs = CMS.settings.githubSettings;
+      var gus = CMS.settings.githubUserSettings;
+      var gs = CMS.settings.githubSettings;
       url = gs.host + '/repos/' + gus.username + '/' + gus.repo + '/contents/' + folder + '?ref=' + gs.branch;
     } else {
       url = folder;
@@ -406,10 +406,9 @@ var CMS = {
     $.ajax({
       url: url,
       success: function (data) {
-
-        var files = [],
-          linkFiles,
-          dateParser = /\d{4}-\d{2}(?:-d{2})?/; // can parse both 2016-01 and 2016-01-01
+        var files = [];
+        var linkFiles;
+        var dateParser = /\d{4}-\d{2}(?:-\d{2})?/; // can parse both 2016-01 and 2016-01-01
 
         if (CMS.settings.mode == 'Github') {
           linkFiles = data;
@@ -419,8 +418,8 @@ var CMS = {
 
         $(linkFiles).each(function (k, f) {
 
-          var filename,
-            downloadLink;
+          var filename;
+          var downloadLink;
 
           if (CMS.settings.mode == 'Github') {
             filename = f.name;
@@ -441,8 +440,8 @@ var CMS = {
 
         });
 
-        var counter = 0,
-          numFiles = files.length;
+        var counter = 0;
+        var numFiles = files.length;
 
         if (numFiles > 0) {
           for (var file of files) {

--- a/js/cms.js
+++ b/js/cms.js
@@ -149,10 +149,10 @@ var CMS = {
 
       var title = '<a href="#">' + post.title + '</a>';
       var date = (post.date.getMonth() + 1) + '/' + post.date.getDate() + '/' +  post.date.getFullYear();
-      var snippet = post.contentData.split('.')[0] + '.';
+      var snippet = '';
       if(typeof CMS.settings.postSnippetSeparator === 'object' || typeof CMS.settings.postSnippetSeparator === 'string') {
         snippet = post.contentData.split(CMS.settings.postSnippetSeparator)[0];
-      } 
+      }
 
       var postLink = $tpl.find('.post-title');
       var postDate = $tpl.find('.post-date');
@@ -163,9 +163,15 @@ var CMS = {
         window.location.hash = 'post/' + post.id;
       });
 
+      $tpl.append('<a href="#">read more...</a>').on('click', function(e) {
+        e.preventDefault();
+        window.location.hash = 'post/' + post.id;
+      });
+
       postLink.html(title);
       postSnippet.html(snippet);
       postDate.html(date);
+
       CMS.settings.mainContainer.append($tpl).hide().fadeIn(CMS.settings.fadeSpeed);
     });
     CMS.renderFooter();

--- a/js/config.js
+++ b/js/config.js
@@ -66,6 +66,13 @@ $(function() {
     githubSettings: {
       branch: 'gh-pages',
       host: 'https://api.github.com'
+    },
+
+    // To have comments, set up an account at disqus.com. Change enabled to
+    // true and enter the shortname below.
+    disqus: {
+      enabled: true,
+      shortname: 'testingsite23'
     }
 
   });

--- a/js/config.js
+++ b/js/config.js
@@ -17,6 +17,7 @@ $(function() {
     // Navigation items
     siteNavItems: [
       { name: 'Github', href: 'https://github.com/yourname', newWindow: false},
+      { name: 'Another Page'},
       { name: 'About'}
     ],
 

--- a/js/config.js
+++ b/js/config.js
@@ -23,8 +23,11 @@ $(function() {
     // Posts folder name
     postsFolder: 'posts',
 
-    // Homepage posts snippet length
+    // Homepage posts snippet length (this doesn't appear to do anything)
     postSnippetLength: 120,
+
+    // Homepage post preview cuttoff (string or regex, defaults to <!--more-->)
+    postSnippetSeparator: /\s*<!--\s*more\s*-->/,
 
     // Pages folder name
     pagesFolder: 'pages',
@@ -49,7 +52,7 @@ $(function() {
 
     // Mode 'Github' for Github Pages, 'Server' for Self Hosted. Defaults
     // to Github
-    mode: 'Github',
+    mode: 'Apache',
 
      // If Github mode is set, your Github username and repo name.
     githubUserSettings: {
@@ -73,7 +76,7 @@ $(function() {
     tables: true,
     breaks: false,
     pedantic: false,
-    sanitize: true,
+    sanitize: false,
     smartLists: true,
     smartypants: false
   });

--- a/pages/another_page.md
+++ b/pages/another_page.md
@@ -1,0 +1,12 @@
+---
+layout: default
+title: Another Page
+---
+
+Hello! This is my awesome about page! Check out some cool links:
+
+* [Smashing Magazine](https://www.smashingmagazine.com)
+* [TechCrunch](http://techcrunch.com/)
+* [Ars Technica](http://arstechnica.com/)
+* [Codoki](http://codoki.com/)
+* [Mozilla Javascript](https://developer.mozilla.org/en-US/docs/Web/JavaScript)

--- a/posts/2016-01-01_example-post.md
+++ b/posts/2016-01-01_example-post.md
@@ -8,6 +8,9 @@ Ball tip bresaola biltong turkey andouille picanha, fatback capicola ham hock te
 
 > Biltong meatloaf pork chop, short loin ham pancetta beef shank ball tip sausage bresaola.
 
+
+<!-- more -->
+
 ## The Bacon
 
 Leberkas brisket shankle salami short loin meatball kevin ham bacon drumstick shank turkey filet mignon strip steak porchetta.

--- a/posts/2016-02-23_another-example-post.md
+++ b/posts/2016-02-23_another-example-post.md
@@ -3,46 +3,118 @@ layout: post
 title: Another Example post
 ---
 
-This post has both types of H2 headers markdown allows, uses `<!-- more -->` as a snippet
-separator, and has Windows line ending.
+This post uses `<!-- more -->` as a snippet separator, Windows line ending, and is filled with as
+many markdown examples as could be found.
 
 <!--more-->
 
-## A H2 Header
+A First Level Header
+====================
 
-Pellentesque accumsan diam a pharetra pretium. Suspendisse scelerisque euismod odio, pulvinar
-fermentum magna consectetur eget. Aliquam tempus, est in sollicitudin tincidunt, mi turpis feugiat
-tortor, non convallis odio lectus id risus. Sed dictum tristique leo nec lobortis. Integer dictum
-risus eget rhoncus eleifend. Aenean mi nisi, eleifend id tincidunt quis, mattis non libero. Nam dui
-lectus, ultricies vitae bibendum nec, consequat et arcu. Nunc fringilla accumsan turpis a feugiat.
-Cras rhoncus, dui eget dignissim interdum, dui nisl pellentesque ante, et commodo sem ligula at
-nisi. Donec eget varius ipsum. Nullam et lorem mattis, tempus augue vitae, facilisis justo.
-Pellentesque dignissim ex quis consequat euismod. Integer in fringilla nunc.
+A Second Level Header
+---------------------
+
+## Another Second Level Header
+
+Now is the time for all good men to come to
+the aid of their country. This is just a
+regular paragraph.
+
+The quick brown fox jumped over the lazy
+dog's back.
+
+### Header 3
+
+> This is a blockquote.
+>
+> This is the second paragraph in the blockquote.
+>
+> ## This is an H2 in a blockquote
+
+Some of these words *are emphasized*.
+Some of these words _are emphasized also_.
+
+Use two asterisks for **strong emphasis**.
+Or, if you prefer, __use two underscores instead__.
+
++   Candy.
++   Gum.
++   Booze.
+
+-   Candy.
+-   Gum.
+-   Booze.
+
+1.  Red
+2.  Green
+3.  Blue
+
+*   A list item.
+
+    With multiple paragraphs.
+
+*   Another item in the list.
+
+This is an [example link](http://example.com/).
+
+This is an [example link](http://example.com/ "With a Title").
+
+I get 10 times more traffic from [Google][1] than from
+[Yahoo][2] or [MSN][3].
+
+[1]: http://google.com/        "Google"
+[2]: http://search.yahoo.com/  "Yahoo Search"
+[3]: http://search.msn.com/    "MSN Search"
+
+I start my morning with a cup of coffee and
+[The New York Times][NY Times].
+
+[ny times]: http://www.nytimes.com/
+
+![alt text](/path/to/img.jpg "Title")
 
 
-The other H2 Header
--------------------
+![alt text][id]
 
-Quisque sodales turpis sit amet metus dictum, sed auctor sapien placerat. Aliquam vitae nisi
-maximus, congue felis vitae, blandit elit. Nunc lobortis sagittis ex sit amet porta. Quisque
-venenatis nulla ut dolor posuere laoreet. Fusce aliquet quis elit vitae scelerisque. Mauris eleifend
-ipsum eu lacus gravida, at vulputate enim condimentum. Phasellus quis lacus dui. Donec ac nibh id
-metus finibus condimentum. Pellentesque habitant morbi tristique senectus et netus et malesuada
-fames ac turpis egestas. Etiam consequat lectus quis urna condimentum, sit amet fringilla ipsum
-venenatis. Suspendisse neque eros, semper mollis eros vitae, blandit rhoncus orci. Fusce sem turpis,
-dignissim mollis diam at, volutpat ultrices enim.
+[id]: /path/to/img.jpg "Title"
 
-Cras vitae vestibulum lorem. Praesent pellentesque ipsum odio, quis mollis elit pretium vitae.
-Curabitur et pulvinar lorem. Quisque ornare, nunc eget mattis aliquam, ante sem lobortis odio, sit
-amet iaculis urna odio non ipsum. Nullam id enim vel turpis luctus pellentesque vitae eget eros.
-Quisque lacinia finibus diam. Morbi sollicitudin mollis urna, ac sollicitudin arcu accumsan laoreet.
-Aliquam at quam vitae velit scelerisque porta. In mollis ornare libero, vel euismod velit hendrerit
-eu. Maecenas dignissim quam ex, eget pulvinar odio ultricies sed. Pellentesque at eleifend urna.
-Vestibulum id congue leo. Vestibulum odio tortor, pretium et velit nec, condimentum pellentesque ex.
+I strongly recommend against using any `<blink>` tags.
 
-Cras id nisl ante. Nullam nisl dui, feugiat finibus ipsum eu, ullamcorper pretium lacus. Nam viverra
-tortor et dui lacinia vestibulum. Donec sit amet aliquam neque, dictum feugiat libero. Morbi
-ultricies consectetur tortor in congue. Suspendisse eget aliquam diam. Nullam vel facilisis sapien.
-Quisque vulputate massa dui, eget pulvinar purus dignissim nec. Curabitur vitae metus dolor. Donec
-pellentesque id leo at consequat. Pellentesque habitant morbi tristique senectus et netus et
-malesuada fames ac turpis egestas.
+I wish SmartyPants used named entities like `&mdash;`
+instead of decimal-encoded entites like `&#8212;`.
+
+If you want your page to validate under XHTML 1.0 Strict,
+you've got to put paragraph tags in your blockquotes:
+
+    <blockquote>
+        <p>For example.</p>
+    </blockquote>
+
+*   Abacus
+    * answer
+*   Bubbles
+    1.  bunk
+    2.  bupkis
+        * BELITTLER
+    3. burper
+*   Cunning
+
+`<code>` spans are delimited
+by backticks.
+
+You can include literal backticks
+like `` `this` ``.
+
+This is a normal paragraph.
+
+    This is a preformatted
+    code block.
+
+---
+
+* * *
+
+- - - -
+
+Roses are red,   
+Violets are blue.

--- a/posts/2016-02-23_another-example-post.md
+++ b/posts/2016-02-23_another-example-post.md
@@ -1,0 +1,48 @@
+---
+layout: post
+title: Another Example post
+---
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris a varius lorem. Sed pellentesque leo
+arcu, sit amet faucibus arcu sodales id. Suspendisse imperdiet at enim sed vestibulum. Sed in felis
+mollis, facilisis metus at, egestas mi. Praesent nec tortor magna. Proin hendrerit ipsum at sagittis
+tincidunt. Vestibulum vitae erat iaculis, eleifend mauris eu, pretium lacus. Nunc accumsan dignissim
+justo sed vehicula. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac
+turpis egestas. Fusce tincidunt eros quis nulla efficitur viverra. Sed mattis mi vel velit iaculis
+fermentum. In ultrices odio id pharetra ornare. Integer scelerisque nulla eget venenatis placerat.
+Donec eget justo ullamcorper, feugiat ex ut, aliquet mi. Aenean vel magna in mi tempus pulvinar.
+
+<!--more-->
+
+Pellentesque accumsan diam a pharetra pretium. Suspendisse scelerisque euismod odio, pulvinar
+fermentum magna consectetur eget. Aliquam tempus, est in sollicitudin tincidunt, mi turpis feugiat
+tortor, non convallis odio lectus id risus. Sed dictum tristique leo nec lobortis. Integer dictum
+risus eget rhoncus eleifend. Aenean mi nisi, eleifend id tincidunt quis, mattis non libero. Nam dui
+lectus, ultricies vitae bibendum nec, consequat et arcu. Nunc fringilla accumsan turpis a feugiat.
+Cras rhoncus, dui eget dignissim interdum, dui nisl pellentesque ante, et commodo sem ligula at
+nisi. Donec eget varius ipsum. Nullam et lorem mattis, tempus augue vitae, facilisis justo.
+Pellentesque dignissim ex quis consequat euismod. Integer in fringilla nunc.
+
+Quisque sodales turpis sit amet metus dictum, sed auctor sapien placerat. Aliquam vitae nisi
+maximus, congue felis vitae, blandit elit. Nunc lobortis sagittis ex sit amet porta. Quisque
+venenatis nulla ut dolor posuere laoreet. Fusce aliquet quis elit vitae scelerisque. Mauris eleifend
+ipsum eu lacus gravida, at vulputate enim condimentum. Phasellus quis lacus dui. Donec ac nibh id
+metus finibus condimentum. Pellentesque habitant morbi tristique senectus et netus et malesuada
+fames ac turpis egestas. Etiam consequat lectus quis urna condimentum, sit amet fringilla ipsum
+venenatis. Suspendisse neque eros, semper mollis eros vitae, blandit rhoncus orci. Fusce sem turpis,
+dignissim mollis diam at, volutpat ultrices enim.
+
+Cras vitae vestibulum lorem. Praesent pellentesque ipsum odio, quis mollis elit pretium vitae.
+Curabitur et pulvinar lorem. Quisque ornare, nunc eget mattis aliquam, ante sem lobortis odio, sit
+amet iaculis urna odio non ipsum. Nullam id enim vel turpis luctus pellentesque vitae eget eros.
+Quisque lacinia finibus diam. Morbi sollicitudin mollis urna, ac sollicitudin arcu accumsan laoreet.
+Aliquam at quam vitae velit scelerisque porta. In mollis ornare libero, vel euismod velit hendrerit
+eu. Maecenas dignissim quam ex, eget pulvinar odio ultricies sed. Pellentesque at eleifend urna.
+Vestibulum id congue leo. Vestibulum odio tortor, pretium et velit nec, condimentum pellentesque ex.
+
+Cras id nisl ante. Nullam nisl dui, feugiat finibus ipsum eu, ullamcorper pretium lacus. Nam viverra
+tortor et dui lacinia vestibulum. Donec sit amet aliquam neque, dictum feugiat libero. Morbi
+ultricies consectetur tortor in congue. Suspendisse eget aliquam diam. Nullam vel facilisis sapien.
+Quisque vulputate massa dui, eget pulvinar purus dignissim nec. Curabitur vitae metus dolor. Donec
+pellentesque id leo at consequat. Pellentesque habitant morbi tristique senectus et netus et
+malesuada fames ac turpis egestas.

--- a/posts/2016-02-23_another-example-post.md
+++ b/posts/2016-02-23_another-example-post.md
@@ -3,16 +3,12 @@ layout: post
 title: Another Example post
 ---
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris a varius lorem. Sed pellentesque leo
-arcu, sit amet faucibus arcu sodales id. Suspendisse imperdiet at enim sed vestibulum. Sed in felis
-mollis, facilisis metus at, egestas mi. Praesent nec tortor magna. Proin hendrerit ipsum at sagittis
-tincidunt. Vestibulum vitae erat iaculis, eleifend mauris eu, pretium lacus. Nunc accumsan dignissim
-justo sed vehicula. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac
-turpis egestas. Fusce tincidunt eros quis nulla efficitur viverra. Sed mattis mi vel velit iaculis
-fermentum. In ultrices odio id pharetra ornare. Integer scelerisque nulla eget venenatis placerat.
-Donec eget justo ullamcorper, feugiat ex ut, aliquet mi. Aenean vel magna in mi tempus pulvinar.
+This post has both types of H2 headers markdown allows, uses `<!-- more -->` as a snippet
+separator, and has Windows line ending.
 
 <!--more-->
+
+## A H2 Header
 
 Pellentesque accumsan diam a pharetra pretium. Suspendisse scelerisque euismod odio, pulvinar
 fermentum magna consectetur eget. Aliquam tempus, est in sollicitudin tincidunt, mi turpis feugiat
@@ -22,6 +18,10 @@ lectus, ultricies vitae bibendum nec, consequat et arcu. Nunc fringilla accumsan
 Cras rhoncus, dui eget dignissim interdum, dui nisl pellentesque ante, et commodo sem ligula at
 nisi. Donec eget varius ipsum. Nullam et lorem mattis, tempus augue vitae, facilisis justo.
 Pellentesque dignissim ex quis consequat euismod. Integer in fringilla nunc.
+
+
+The other H2 Header
+-------------------
 
 Quisque sodales turpis sit amet metus dictum, sed auctor sapien placerat. Aliquam vitae nisi
 maximus, congue felis vitae, blandit elit. Nunc lobortis sagittis ex sit amet porta. Quisque

--- a/posts/2016-02-23_another-example-post.md
+++ b/posts/2016-02-23_another-example-post.md
@@ -73,7 +73,6 @@ I start my morning with a cup of coffee and
 
 ![alt text](/path/to/img.jpg "Title")
 
-
 ![alt text][id]
 
 [id]: /path/to/img.jpg "Title"


### PR DESCRIPTION
Please forgive me, it's my first pull request :)

Post separator only split on the first sentence, so this has an option to separate on a user defined string or regex (default is <!-- more -->).

Also made a change to parseContent method so the other style of markdown h2 headers can be used (issue #51). I tested this for all the cases I can think of in a new example post, but maybe not thoroughly enough. 
