### PR TITLE
Parse seperator patch

### DIFF
--- a/js/cms.js
+++ b/js/cms.js
@@ -27,7 +27,7 @@ var CMS = {
     mainContainer: $(document.getElementsByClassName('cms_main')),
     footerContainer: $(document.getElementsByClassName('cms_footer')),
     footerText: '&copy; ' + new Date().getFullYear() + ' All Rights Reserved.',
-    parseSeperator: /^---/m,
+    parseSeperator: /^---$/m,
     postsOnFrontpage: true,
     pageAsFrontpage: '',
     postsOnUrl: '',

--- a/js/cms.js
+++ b/js/cms.js
@@ -27,7 +27,7 @@ var CMS = {
     mainContainer: $(document.getElementsByClassName('cms_main')),
     footerContainer: $(document.getElementsByClassName('cms_footer')),
     footerText: '&copy; ' + new Date().getFullYear() + ' All Rights Reserved.',
-    parseSeperator: '---',
+    parseSeperator: /^---/m,
     postsOnFrontpage: true,
     pageAsFrontpage: '',
     postsOnUrl: '',


### PR DESCRIPTION
Replaces `parseSeperator: '---',`

With `parseSeperator: /^---$/m,`

This matches exactly 3 dashes and ensures they are the only characters on their line.
This prevents conflict with table AND alternate header syntax.

Horizontal lines would require 4 or more dashes.
