### PR TITLE
Premature setNavigation() invocation fix (issue #65)

### DIFF
--- a/js/cms.js
+++ b/js/cms.js
@@ -242,7 +242,7 @@ var CMS = {
     }
 
     // Execute after all content is loaded
-    if (counter === numFiles) {
+    if (CMS[type + 's'].length === numFiles) {
       CMS.contentLoaded(type);
     }
   },


### PR DESCRIPTION
As described in issue #65: 
Pages are loaded asynchronously and the "counter" (value that is accessed by Ajax success) is passed by iterating the filenames in getFiles(). The navigation bar is loaded when the counter is equal to the count of the pages. There can be a situation where a last page is loaded first and the navigation bar is created prematurely.

Fix just checks if `CMS.posts.length` or `CMS.pages.length` (already loaded posts/pages) are equal to numFiles variable.
