### PR TITLE
"Page as frontpage" feature implemented

### DIFF
--- a/js/cms.js
+++ b/js/cms.js
@@ -80,7 +80,11 @@ var CMS = {
 
       // Main view / Frontpage
       '' : function () {
+        if (typeof CMS.settings.pageAsFrontpage === 'undefined' || CMS.settings.pageAsFrontpage === '') {
           CMS.renderPosts();
+        } else {
+          CMS.renderPage(CMS.settings.pageAsFrontpage);
+        }
       },
 
       // Post view / single view


### PR DESCRIPTION
If `CMS.settings.pageAsFrontpage` is defined and not an empty string, page is rendered as frontpage.
