### PR TITLE
"Page as frontpage" feature implemented

### DIFF
--- a/js/cms.js
+++ b/js/cms.js
@@ -87,6 +87,11 @@ var CMS = {
         }
       },
 
+      // Post list if 'page' is the frontpage
+      '#posts' : function () {
+        CMS.renderPosts();
+      },
+
       // Post view / single view
       '#post' : function () {
         var id = url.split('#post/')[1].trim();

--- a/js/cms.js
+++ b/js/cms.js
@@ -80,7 +80,11 @@ var CMS = {
 
       // Main view / Frontpage
       '' : function () {
+        if (typeof CMS.settings.pageAsFrontpage === 'undefined' || CMS.settings.pageAsFrontpage === '') {
           CMS.renderPosts();
+        } else {
+          CMS.renderPage(CMS.settings.pageAsFrontpage);
+        }
       },
 
       // Post view / single view


### PR DESCRIPTION
If `CMS.settings.pageAsFrontpage` is defined and not an empty string, page is rendered as frontpage.

To have a link to the list of posts, entry in siteNavItems needs to be added:

```
{
   name: 'blog',
   href: '#posts',
   newWindow: false
}
```
