### PR TITLE
Fix url type path not being prefixed properly

### DIFF
--- a/dist/cms.js
+++ b/dist/cms.js
@@ -717,6 +717,11 @@ var CMS = (function () {
         var _this3 = this;
 
         var promises = []; // Load file content
+        // prefix url path
+        for (let x = 0; x < this.files.length; x++) {
+            const obj = this.files[x];
+            obj.url = this.type + "/" + obj.url;
+        }
 
         this.files.forEach(function (file, i) {
           file.getContent(function (success, error) {


### PR DESCRIPTION
Hello, me and @ether0w recently ran into an issue with using this repository from an Apache host.
We had an issue where all content text was simply just "undefined".
Investigating this issue we noticed this was due to cms.js not locating the packed `.md` files correctly, since it was requesting at the root directory (e.g. `yourdomain.com/blogpost1.md`) instead of the proper subdirectory (e.g. `yourdomain.com/posts/blogpost1.md`).
This patch fixes this issue.